### PR TITLE
[S] Add Criterion with sample benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,10 @@ fallible-iterator = "0.1.5"
 sha2 = "0.7.1"
 chrono = { version = "0.4.5", features = ["serde"] }
 uuid = { version = "0.5.1", features = ["serde", "v4"] }
+
+[dev-dependencies]
+criterion = "0.2.4"
+
+[[bench]]
+name = "testhelpers"
+harness = false

--- a/benches/testhelpers.rs
+++ b/benches/testhelpers.rs
@@ -1,0 +1,49 @@
+#[macro_use]
+extern crate criterion;
+extern crate event_store_rs;
+
+use criterion::Criterion;
+use event_store_rs::testhelpers::{
+    TestCounterEntity, TestDecrementEvent, TestEvents, TestIncrementEvent,
+};
+use event_store_rs::Aggregator;
+
+fn aggregate_from_default(c: &mut Criterion) {
+    c.bench_function("aggregate from default", move |b| {
+        b.iter(|| {
+            let events = vec![
+                TestEvents::Inc(TestIncrementEvent {
+                    by: 1,
+                    ident: "it_aggregates_events".into(),
+                }),
+                TestEvents::Inc(TestIncrementEvent {
+                    by: 1,
+                    ident: "it_aggregates_events".into(),
+                }),
+                TestEvents::Dec(TestDecrementEvent {
+                    by: 2,
+                    ident: "it_aggregates_events".into(),
+                }),
+                TestEvents::Inc(TestIncrementEvent {
+                    by: 2,
+                    ident: "it_aggregates_events".into(),
+                }),
+                TestEvents::Dec(TestDecrementEvent {
+                    by: 3,
+                    ident: "it_aggregates_events".into(),
+                }),
+                TestEvents::Dec(TestDecrementEvent {
+                    by: 3,
+                    ident: "it_aggregates_events".into(),
+                }),
+            ];
+
+            let _result: TestCounterEntity = events
+                .iter()
+                .fold(TestCounterEntity::default(), TestCounterEntity::apply_event);
+        })
+    });
+}
+
+criterion_group!(testhelpers, aggregate_from_default);
+criterion_main!(testhelpers);


### PR DESCRIPTION
Run with `cargo bench`, reports are generated into `target/criterion`. We should add more/better benchmarks in the future. This PR just adds the framework and ability to do so.

Closes #2 