### PR TITLE
[S] Fix travis links, rename crate to event-store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "event-store-rs"
+name = "event-store"
 version = "0.1.0"
 authors = ["James Waples <jamwaffles@gmail.com>"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["James Waples <jamwaffles@gmail.com>"]
 
 [badges]
-travis-ci = { repository = "jamwaffles/event-store-rs", branch = "master" }
+travis-ci = { repository = "repositive/event-store-rs", branch = "master" }
 
 [dependencies]
 serde = "1.0.71"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Event Store in Rust
 
-[![Build Status](https://travis-ci.org/jamwaffles/event-store-rs.svg?branch=master)](https://travis-ci.org/jamwaffles/event-store-rs)
+[![Build Status](https://travis-ci.org/repositive/event-store-rs.svg?branch=master)](https://travis-ci.org/repositive/event-store-rs)
 
 Event store, but in Rust
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,8 @@ pub trait Event {}
 /// ```rust
 /// # #[macro_use]
 /// # extern crate serde_derive;
-/// # extern crate event_store_rs;
-/// # use event_store_rs::Events;
+/// # extern crate event_store;
+/// # use event_store::Events;
 /// #[derive(Serialize, Deserialize)]
 /// struct EventA;
 ///

--- a/tests/pg.rs
+++ b/tests/pg.rs
@@ -1,10 +1,10 @@
-extern crate event_store_rs;
+extern crate event_store;
 extern crate postgres;
 
-use event_store_rs::testhelpers::{
+use event_store::testhelpers::{
     TestCounterEntity, TestDecrementEvent, TestEvents, TestIncrementEvent,
 };
-use event_store_rs::{
+use event_store::{
     adapters::{PgCacheAdapter, PgStoreAdapter, StubEmitterAdapter},
     Aggregator, EventStore, Store,
 };


### PR DESCRIPTION
Used to point to @jamwaffles' repo, now points to Repositive.