### PR TITLE
[S] Support/fix imports, remove combined event `type` field

### DIFF
--- a/event-store-derive/Cargo.toml
+++ b/event-store-derive/Cargo.toml
@@ -10,7 +10,6 @@ proc-macro2 = "0.4.15"
 serde = "1.0.75"
 serde_derive = "1.0.75"
 event-store-derive-internals = { path = "../event-store-derive-internals" }
-serde_json = "1.0.26"
 
 [lib]
 proc-macro = true

--- a/event-store-derive/src/derive_enum.rs
+++ b/event-store-derive/src/derive_enum.rs
@@ -172,42 +172,6 @@ pub fn derive_enum(parsed: &DeriveInput, enum_body: &DataEnum) -> TokenStream {
     let namespace_and_types_quoted_clone = namespace_and_types_quoted.clone();
     let namespaces_quoted_clone = namespaces_quoted.clone();
     let types_quoted_clone = types_quoted.clone();
-    let out = quote! {
-        // Get the type or namespace of an instance of an events enum
-        impl event_store_derive_internals::Events for #item_ident {
-            fn event_namespace_and_type(&self) -> &'static str {
-                match self {
-                    #(
-                      #struct_idents_clone1 => #namespace_and_types_quoted_clone,
-                    )*
-                }
-            }
-            fn event_namespace(&self) -> &'static str {
-                match self {
-                    #(
-                      #struct_idents_clone2 => #namespaces_quoted_clone,
-                    )*
-                }
-            }
-            fn event_type(&self) -> &'static str {
-                match self {
-                    #(
-                      #struct_idents_clone3 => #types_quoted_clone,
-                    )*
-                }
-            }
-        }
-
-        #(
-            impl event_store_derive_internals::EventData for #struct_idents {
-                fn event_namespace_and_type() -> &'static str { #namespace_and_types_quoted }
-                fn event_namespace() -> &'static str { #namespaces_quoted }
-                fn event_type() -> &'static str { #types_quoted }
-            }
-        )*
-        #ser
-        #de
-    };
 
     let dummy_const = Ident::new(
         &format!("_IMPL_EVENT_STORE_ENUM_FOR_{}", item_ident),
@@ -225,7 +189,40 @@ pub fn derive_enum(parsed: &DeriveInput, enum_body: &DataEnum) -> TokenStream {
             use serde::de::{Deserialize, Deserializer};
             use serde::ser::{Serialize, Serializer, SerializeMap};
 
-            #out
+            // Get the type or namespace of an instance of an events enum
+            impl event_store_derive_internals::Events for #item_ident {
+                fn event_namespace_and_type(&self) -> &'static str {
+                    match self {
+                        #(
+                          #struct_idents_clone1 => #namespace_and_types_quoted_clone,
+                        )*
+                    }
+                }
+                fn event_namespace(&self) -> &'static str {
+                    match self {
+                        #(
+                          #struct_idents_clone2 => #namespaces_quoted_clone,
+                        )*
+                    }
+                }
+                fn event_type(&self) -> &'static str {
+                    match self {
+                        #(
+                          #struct_idents_clone3 => #types_quoted_clone,
+                        )*
+                    }
+                }
+            }
+
+            #(
+                impl event_store_derive_internals::EventData for #struct_idents {
+                    fn event_namespace_and_type() -> &'static str { #namespace_and_types_quoted }
+                    fn event_namespace() -> &'static str { #namespaces_quoted }
+                    fn event_type() -> &'static str { #types_quoted }
+                }
+            )*
+            #ser
+            #de
         };
     }
 }

--- a/event-store-derive/src/derive_enum.rs
+++ b/event-store-derive/src/derive_enum.rs
@@ -147,8 +147,15 @@ pub fn derive_enum(parsed: &DeriveInput, enum_body: &DataEnum) -> TokenStream {
         ref enum_body,
         ref item_ident,
         ref renamed_variant_idents,
+        ref variant_idents,
         ..
     } = &info;
+
+    let item_idents = repeat(item_ident);
+    let item_idents2 = repeat(item_ident);
+    let item_idents3 = repeat(item_ident);
+    let variant_idents2 = variant_idents.iter();
+    let variant_idents3 = variant_idents.iter();
 
     let namespaces_quoted = get_quoted_namespaces(&enum_body, &enum_namespace);
 
@@ -164,10 +171,6 @@ pub fn derive_enum(parsed: &DeriveInput, enum_body: &DataEnum) -> TokenStream {
     let de = impl_deserialize(&info);
 
     let struct_idents = get_enum_struct_names(&enum_body);
-
-    let struct_idents_clone1 = struct_idents.clone();
-    let struct_idents_clone2 = struct_idents.clone();
-    let struct_idents_clone3 = struct_idents.clone();
 
     let namespace_and_types_quoted_clone = namespace_and_types_quoted.clone();
     let namespaces_quoted_clone = namespaces_quoted.clone();
@@ -192,23 +195,17 @@ pub fn derive_enum(parsed: &DeriveInput, enum_body: &DataEnum) -> TokenStream {
             impl event_store_derive_internals::Events for #item_ident {
                 fn event_namespace_and_type(&self) -> &'static str {
                     match self {
-                        #(
-                          #struct_idents_clone1 => #namespace_and_types_quoted_clone,
-                        )*
+                        #(#item_idents::#variant_idents(_) => #namespace_and_types_quoted_clone,)*
                     }
                 }
                 fn event_namespace(&self) -> &'static str {
                     match self {
-                        #(
-                          #struct_idents_clone2 => #namespaces_quoted_clone,
-                        )*
+                        #(#item_idents2::#variant_idents2(_) => #namespaces_quoted_clone,)*
                     }
                 }
                 fn event_type(&self) -> &'static str {
                     match self {
-                        #(
-                          #struct_idents_clone3 => #types_quoted_clone,
-                        )*
+                        #(#item_idents3::#variant_idents3(_) => #types_quoted_clone,)*
                     }
                 }
             }

--- a/event-store-derive/src/ns.rs
+++ b/event-store-derive/src/ns.rs
@@ -35,8 +35,7 @@ impl EnumInfo {
                 let name_override = get_attribute_ident(&v.attrs, "rename");
 
                 name_override.unwrap_or(v.ident.clone())
-            })
-            .collect::<Vec<Ident>>();
+            }).collect::<Vec<Ident>>();
 
         Self {
             enum_namespace,
@@ -65,8 +64,7 @@ pub fn get_attribute_ident(input: &Vec<Attribute>, attribute_name: &'static str)
                         Group(_) => true,
                         _ => false,
                     })
-                })
-                .and_then(|tt| match tt {
+                }).and_then(|tt| match tt {
                     Group(g) => {
                         let mut it = g.stream().into_iter();
 
@@ -74,7 +72,8 @@ pub fn get_attribute_ident(input: &Vec<Attribute>, attribute_name: &'static str)
                             (
                                 Some(TokenTree::Ident(ref ident)),
                                 Some(TokenTree::Literal(ref attribute_value)),
-                            ) if *ident == ident_match =>
+                            )
+                                if *ident == ident_match =>
                             {
                                 Some(Ident::new(
                                     attribute_value.to_string().trim_matches('"').into(),
@@ -86,8 +85,7 @@ pub fn get_attribute_ident(input: &Vec<Attribute>, attribute_name: &'static str)
                     }
                     _ => None,
                 })
-        })
-        .next()
+        }).next()
 }
 
 pub fn get_enum_struct_names(enum_body: &DataEnum) -> Vec<TokenStream> {
@@ -101,8 +99,7 @@ pub fn get_enum_struct_names(enum_body: &DataEnum) -> Vec<TokenStream> {
                 .next()
                 .map(|field| field.ty.clone().into_token_stream())
                 .expect("Expected struct type")
-        })
-        .collect::<Vec<TokenStream>>()
+        }).collect::<Vec<TokenStream>>()
 }
 
 pub fn expand_derive_namespace(parsed: &DeriveInput) -> TokenStream {
@@ -122,6 +119,5 @@ pub fn get_quoted_namespaces(enum_body: &DataEnum, default_namespace: &Ident) ->
             get_attribute_ident(&variant.attrs, "namespace")
                 .unwrap_or(default_namespace.clone())
                 .to_string()
-        })
-        .collect()
+        }).collect()
 }

--- a/event-store/benches/testhelpers.rs
+++ b/event-store/benches/testhelpers.rs
@@ -62,20 +62,6 @@ fn serialize_event(c: &mut Criterion) {
     });
 }
 
-fn deserialize_old_event(c: &mut Criterion) {
-    let incoming_str = to_string(&json!({
-        "type": "some_namespace.Inc",
-        "by": 1,
-        "ident": "deserialize_event"
-    })).expect("Could not create test event JSON");
-
-    c.bench_function("deserialize old style event", move |b| {
-        b.iter(|| {
-            let _event: TestEvents = from_str(&incoming_str).unwrap();
-        })
-    });
-}
-
 fn deserialize_event(c: &mut Criterion) {
     let incoming_str = to_string(&json!({
         "event_namespace": "some_namespace",
@@ -117,7 +103,6 @@ criterion_group!(
     targets =
         aggregate_from_default,
         serialize_event,
-        deserialize_old_event,
         deserialize_event,
         roundtrip
 );

--- a/event-store/tests/derive_enum.rs
+++ b/event-store/tests/derive_enum.rs
@@ -205,3 +205,35 @@ fn it_gets_variant_strings() {
         assert_eq!(variant.event_type(), expected_ty);
     }
 }
+
+#[test]
+fn it_differentiates_structs_with_same_shape() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct ThingA {
+        foo: u32,
+    };
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct ThingB {
+        foo: u32,
+    };
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct ThingC {
+        bar: u8,
+    };
+
+    #[derive(Events, PartialEq, Debug, Clone)]
+    #[event_store(namespace = "some_namespace")]
+    enum TestEnum {
+        A(ThingA),
+        B(ThingB),
+        C(ThingC),
+    }
+
+    let v: TestEnum = from_value(json!({
+        "event_type": "B",
+        "event_namespace": "some_namespace",
+        "foo": 100
+    })).unwrap();
+
+    assert_eq!(v, TestEnum::B(ThingB { foo: 100 }));
+}

--- a/event-store/tests/derive_enum.rs
+++ b/event-store/tests/derive_enum.rs
@@ -50,7 +50,6 @@ fn it_serializes_enums() {
     assert_eq!(
         to_value(TestEnum::TestStruct(TestStruct { thing: 100 })).unwrap(),
         json!({
-            "type": "some_namespace.TestStruct",
             "event_namespace": "some_namespace",
             "event_type": "TestStruct",
             "thing": 100,
@@ -79,7 +78,6 @@ fn it_roundtrips() {
     assert_eq!(
         encoded,
         json!({
-            "type": "some_namespace.Variant",
             "event_namespace": "some_namespace",
             "event_type": "Variant",
             "thing": 100,
@@ -109,7 +107,6 @@ fn it_roundtrips_overridden_namespaces() {
     assert_eq!(
         encoded,
         json!({
-            "type": "other_ns.Variant",
             "event_namespace": "other_ns",
             "event_type": "Variant",
             "thing": 100,
@@ -145,7 +142,6 @@ fn it_roundtrips_renamed_variants() {
     assert_eq!(
         encoded,
         json!({
-            "type": "some_namespace.RenamedTestStruct",
             "event_namespace": "some_namespace",
             "event_type": "RenamedTestStruct",
             "thing": 100,

--- a/event-store/tests/derive_struct.rs
+++ b/event-store/tests/derive_struct.rs
@@ -1,7 +1,6 @@
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
 #[macro_use]
 extern crate event_store_derive;
 extern crate event_store;

--- a/event-store/tests/pg.rs
+++ b/event-store/tests/pg.rs
@@ -59,7 +59,7 @@ fn it_queries_the_database() {
     let cache_adapter = PgCacheAdapter::new(&conn);
     let emitter_adapter = StubEmitterAdapter::new();
 
-    let mut store = EventStore::new(store_adapter, cache_adapter, emitter_adapter);
+    let store = EventStore::new(store_adapter, cache_adapter, emitter_adapter);
 
     let ident = String::from("dbquery");
 
@@ -87,7 +87,7 @@ fn it_saves_events() {
     let cache_adapter = PgCacheAdapter::new(&conn);
     let emitter_adapter = StubEmitterAdapter::new();
 
-    let mut store = EventStore::new(store_adapter, cache_adapter, emitter_adapter);
+    let store = EventStore::new(store_adapter, cache_adapter, emitter_adapter);
 
     let event = TestEvents::Inc(TestIncrementEvent {
         by: 123123,
@@ -115,7 +115,7 @@ fn it_uses_the_aggregate_cache() {
     let cache_adapter = PgCacheAdapter::new(&conn);
     let emitter_adapter = StubEmitterAdapter::new();
 
-    let mut store = EventStore::new(store_adapter, cache_adapter, emitter_adapter);
+    let store = EventStore::new(store_adapter, cache_adapter, emitter_adapter);
 
     assert!(
         store


### PR DESCRIPTION
* [x] Remove reliance on serde_json
* [x] Hide event_store_derive_internals import
* [x] BREAKING: Remove `type` support; only `event_type` AND `event_namespace` are supported. Ser/de is made much harder by supporting both. By only supporting one, we can leverage [all the existing code](https://docs.serde.rs/serde_json/value/enum.Value.html) from Serde. Interop is easy for other repos; just add `event_type` and `event_namespace` to any events to be supported by event-store-rs.