### PR TITLE
[S] Move env_logger to dev dependencies

### DIFF
--- a/event-store/Cargo.toml
+++ b/event-store/Cargo.toml
@@ -18,7 +18,6 @@ uuid = { version = "0.5.1", features = ["serde", "v4"] }
 event-store-derive = { path = "../event-store-derive" }
 event-store-derive-internals = { path = "../event-store-derive-internals" }
 log = "0.4"
-env_logger = "0.5.13"
 lapin-futures = "0.13"
 futures = "0.1.23"
 tokio = "0.1.8"
@@ -26,6 +25,7 @@ tokio = "0.1.8"
 
 [dev-dependencies]
 criterion = "0.2.4"
+env_logger = "0.5.13"
 
 [[bench]]
 name = "testhelpers"

--- a/event-store/src/lib.rs
+++ b/event-store/src/lib.rs
@@ -15,7 +15,6 @@ extern crate sha2;
 extern crate uuid;
 #[macro_use]
 extern crate log;
-extern crate env_logger;
 extern crate futures;
 extern crate lapin_futures as lapin;
 extern crate tokio;

--- a/event-store/tests/amqp.rs
+++ b/event-store/tests/amqp.rs
@@ -1,9 +1,8 @@
+extern crate env_logger;
 extern crate event_store;
 extern crate futures;
 extern crate serde_json;
 extern crate tokio;
-
-extern crate env_logger;
 
 use event_store::adapters::{AMQPEmitterAdapter, EmitterAdapter};
 use event_store::testhelpers::{TestEvents, TestIncrementEvent};


### PR DESCRIPTION
The [log crate docs](https://crates.io/crates/log) say that libs should _only_ include the `log` crate. Actual impls/transports should be included by binary crates that use such libs. @Istar-Eldritch sorry I didn't catch this in your previous PR.