### PR TITLE
[S] Use R2D2 in tests to ensure the store supports it

### DIFF
--- a/event-store/Cargo.toml
+++ b/event-store/Cargo.toml
@@ -22,9 +22,10 @@ lapin-futures = "0.13"
 futures = "0.1.23"
 tokio = "0.1.8"
 
-
 [dev-dependencies]
 criterion = "0.2.4"
+r2d2_postgres = "0.14.0"
+r2d2 = "0.8.2"
 env_logger = "0.5.13"
 
 [[bench]]


### PR DESCRIPTION
The tests work/pass, so it seems R2D2 is clever enough in how it wraps a connection to not require any changes to the actual code, which is kool.

Closes #18 

[CMP-349](https://repositive.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=CMP&modal=detail&selectedIssue=CMP-349)