### PR TITLE
[F] Add BoxedFuture type alias

### DIFF
--- a/event-store/src/adapters/mod.rs
+++ b/event-store/src/adapters/mod.rs
@@ -15,6 +15,7 @@ use chrono::{DateTime, Utc};
 use futures::future::Future;
 use serde::{de::DeserializeOwned, Serialize};
 use std::io;
+use utils::BoxedFuture;
 use Aggregator;
 use Event;
 use EventData;
@@ -58,13 +59,10 @@ pub trait CacheAdapter<K> {
 /// Event emitter interface
 pub trait EmitterAdapter {
     /// Emit an event
-    fn emit<E: Events + Sync>(
-        &self,
-        event: &Event<E>,
-    ) -> Box<Future<Item = (), Error = io::Error> + Send + Sync>;
+    fn emit<E: Events + Sync>(&self, event: &Event<E>) -> BoxedFuture<(), io::Error>;
 
     /// Subscribe to an event
-    fn subscribe<ED, H>(&self, handler: H) -> Box<Future<Item = (), Error = io::Error> + Send>
+    fn subscribe<ED, H>(&self, handler: H) -> BoxedFuture<(), io::Error>
     where
         ED: EventData + 'static,
         H: Fn(&Event<ED>) -> () + Send + Sync + 'static;

--- a/event-store/src/adapters/stub/emitter.rs
+++ b/event-store/src/adapters/stub/emitter.rs
@@ -1,8 +1,9 @@
 //! Stub emitter implementation
 
 use adapters::EmitterAdapter;
-use futures::future::{ok, Future};
+use futures::future::ok;
 use std::io::Error;
+use utils::BoxedFuture;
 use Event;
 use EventData;
 use Events;
@@ -18,17 +19,11 @@ impl StubEmitterAdapter {
 }
 
 impl EmitterAdapter for StubEmitterAdapter {
-    fn emit<E: Events>(
-        &self,
-        _event: &Event<E>,
-    ) -> Box<Future<Item = (), Error = Error> + Send + Sync> {
+    fn emit<E: Events>(&self, _event: &Event<E>) -> BoxedFuture<(), Error> {
         Box::new(ok(()))
     }
 
-    fn subscribe<ED: EventData, H>(
-        &self,
-        _handler: H,
-    ) -> Box<Future<Item = (), Error = Error> + Send>
+    fn subscribe<ED: EventData, H>(&self, _handler: H) -> BoxedFuture<(), Error>
     where
         H: Fn(&Event<ED>) -> (),
     {

--- a/event-store/src/lib.rs
+++ b/event-store/src/lib.rs
@@ -21,6 +21,7 @@ extern crate tokio;
 
 pub mod adapters;
 pub mod testhelpers;
+mod utils;
 
 use adapters::{CacheAdapter, CacheResult, EmitterAdapter, StoreAdapter};
 use chrono::prelude::*;

--- a/event-store/src/utils.rs
+++ b/event-store/src/utils.rs
@@ -1,0 +1,3 @@
+use futures::future::Future;
+
+pub type BoxedFuture<T, E> = Box<Future<Item = T, Error = E> + Send>;


### PR DESCRIPTION
Simplifies the return types by adding a new [BoxedFuture](https://github.com/repositive/event-store-rs/compare/feature/boxed-future?expand=1#diff-1636e5cd6dd9d28bef0b0fbec6842d0cR3) type alias