### PR TITLE
[S] Require Clone for EmitterAdapter

### DIFF
--- a/event-store/src/adapters/amqp/emitter.rs
+++ b/event-store/src/adapters/amqp/emitter.rs
@@ -21,6 +21,7 @@ use EventData;
 use Events;
 
 /// AMQP emitter
+#[derive(Clone)]
 pub struct AMQPEmitterAdapter {
     channel: Channel<TcpStream>,
     exchange: String,

--- a/event-store/src/adapters/mod.rs
+++ b/event-store/src/adapters/mod.rs
@@ -12,7 +12,6 @@ pub use self::amqp::AMQPEmitterAdapter;
 pub use self::pg::{PgCacheAdapter, PgQuery, PgStoreAdapter};
 pub use self::stub::StubEmitterAdapter;
 use chrono::{DateTime, Utc};
-use futures::future::Future;
 use serde::{de::DeserializeOwned, Serialize};
 use std::io;
 use utils::BoxedFuture;
@@ -57,7 +56,7 @@ pub trait CacheAdapter<K> {
 /// Closure called when an incoming event must be handled
 
 /// Event emitter interface
-pub trait EmitterAdapter {
+pub trait EmitterAdapter: Clone {
     /// Emit an event
     fn emit<E: Events + Sync>(&self, event: &Event<E>) -> BoxedFuture<(), io::Error>;
 

--- a/event-store/src/adapters/stub/emitter.rs
+++ b/event-store/src/adapters/stub/emitter.rs
@@ -9,6 +9,7 @@ use EventData;
 use Events;
 
 /// Stub event emitter
+#[derive(Clone)]
 pub struct StubEmitterAdapter {}
 
 impl StubEmitterAdapter {


### PR DESCRIPTION
This is so emitters can be `.clone()`d for things like running in multiple Actix threads.