### PR TITLE
[S] CMP-487 Clean DB tables before every PG test

### DIFF
--- a/event-store/src/lib.rs
+++ b/event-store/src/lib.rs
@@ -29,6 +29,7 @@ mod event_context;
 pub mod prelude;
 mod store;
 mod store_query;
+#[macro_use]
 pub mod testhelpers;
 mod utils;
 

--- a/event-store/src/testhelpers.rs
+++ b/event-store/src/testhelpers.rs
@@ -1,9 +1,14 @@
 //! Test helpers. Do not use in application code.
 
 use adapters::PgQuery;
+use adapters::{PgCacheAdapter, PgStoreAdapter, StubEmitterAdapter};
 use prelude::*;
+use r2d2;
+use r2d2::Pool;
 use r2d2_postgres::postgres::types::ToSql;
+use r2d2_postgres::{PostgresConnectionManager, TlsMode};
 use Event;
+use EventStore;
 
 /// Test event
 #[derive(EventData, Debug)]
@@ -68,4 +73,40 @@ impl<'a> Aggregator<TestEvents, String, PgQuery<'a>> for TestCounterEntity {
 
         PgQuery::new("select * from events where data->>'ident' = $1", params)
     }
+}
+
+/// Create an event store from a Postgres connection pool
+#[macro_export]
+macro_rules! pg_store {
+    ($conn:ident) => {{
+        let store_adapter = PgStoreAdapter::new($conn.clone());
+        let cache_adapter = PgCacheAdapter::new($conn.clone());
+        let emitter_adapter = StubEmitterAdapter::new();
+
+        EventStore::new(store_adapter, cache_adapter, emitter_adapter)
+    }};
+}
+
+/// Delete all `TestEvent` events matching an identifier from the `events` table
+#[macro_export]
+macro_rules! pg_delete_events {
+    ($conn:ident, $ident:expr) => {{
+        $conn
+            .get()
+            .unwrap()
+            .execute("DELETE FROM events WHERE data->>'ident' = $1", &[&$ident])
+            .expect("Failed to delete events");
+    }};
+}
+
+/// Remove EVERY entry from the `aggregate_cache` table
+#[macro_export]
+macro_rules! pg_empty_cache {
+    ($conn:ident) => {{
+        $conn
+            .get()
+            .unwrap()
+            .execute("TRUNCATE aggregate_cache", &[])
+            .expect("Failed to trunacte cache table");
+    }};
 }

--- a/event-store/tests/pg.rs
+++ b/event-store/tests/pg.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 extern crate event_store;
 extern crate r2d2;
 extern crate r2d2_postgres;
@@ -29,14 +30,10 @@ fn connect() -> Pool<PostgresConnectionManager> {
 #[test]
 fn it_queries_the_database() {
     let conn = connect();
+    let store = pg_store!(conn);
+    let ident = String::from("it_queries_the_database");
 
-    let store_adapter = PgStoreAdapter::new(conn.clone());
-    let cache_adapter = PgCacheAdapter::new(conn.clone());
-    let emitter_adapter = StubEmitterAdapter::new();
-
-    let store = EventStore::new(store_adapter, cache_adapter, emitter_adapter);
-
-    let ident = String::from("dbquery");
+    pg_delete_events!(conn, ident);
 
     assert!(
         block_on_all(store.save(Event::from_data(TestIncrementEvent {
@@ -53,16 +50,14 @@ fn it_queries_the_database() {
 #[test]
 fn it_saves_events() {
     let conn = connect();
+    let store = pg_store!(conn);
+    let ident = String::from("it_saves_events");
 
-    let store_adapter = PgStoreAdapter::new(conn.clone());
-    let cache_adapter = PgCacheAdapter::new(conn.clone());
-    let emitter_adapter = StubEmitterAdapter::new();
-
-    let store = EventStore::new(store_adapter, cache_adapter, emitter_adapter);
+    pg_delete_events!(conn, ident);
 
     let event = TestIncrementEvent {
         by: 123123,
-        ident: "it_saves_events".into(),
+        ident: ident.clone(),
     };
 
     assert!(block_on_all(store.save(Event::from_data(event))).is_ok());
@@ -71,42 +66,30 @@ fn it_saves_events() {
 #[test]
 fn it_uses_the_aggregate_cache() {
     let conn = connect();
+    let store = pg_store!(conn);
+    let ident = String::from("it_uses_the_aggregate_cache");
 
-    let ident = "aggregatecache";
-
-    conn.get()
-        .unwrap()
-        .execute("DELETE FROM events WHERE data->>'ident' = $1", &[&ident])
-        .expect("Truncate");
-    conn.get()
-        .unwrap()
-        .execute("TRUNCATE aggregate_cache", &[])
-        .expect("Truncate");
-
-    let store_adapter = PgStoreAdapter::new(conn.clone());
-    let cache_adapter = PgCacheAdapter::new(conn.clone());
-    let emitter_adapter = StubEmitterAdapter::new();
-
-    let store = EventStore::new(store_adapter, cache_adapter, emitter_adapter);
+    pg_delete_events!(conn, ident);
+    pg_empty_cache!(conn);
 
     assert!(
         block_on_all(store.save(Event::from_data(TestIncrementEvent {
             by: 1,
-            ident: ident.into()
+            ident: ident.clone()
         }))).is_ok()
     );
 
     assert!(
         block_on_all(store.save(Event::from_data(TestIncrementEvent {
             by: 2,
-            ident: ident.into()
+            ident: ident.clone()
         }))).is_ok()
     );
 
     // Wait for DB to process
     thread::sleep(Duration::from_millis(10));
 
-    let entity: TestCounterEntity = block_on_all(store.aggregate(ident.into())).unwrap();
+    let entity: TestCounterEntity = block_on_all(store.aggregate(ident)).unwrap();
 
     assert_eq!(entity.counter, 3);
 }

--- a/event-store/tests/pg.rs
+++ b/event-store/tests/pg.rs
@@ -59,7 +59,7 @@ fn it_saves_events() {
     let event = Event::from_data(TestIncrementEvent {
         by: 123123,
         ident: ident.clone(),
-    };
+    });
 
     assert!(block_on_all(store.save(&event)).is_ok());
 }
@@ -75,12 +75,12 @@ fn it_uses_the_aggregate_cache() {
 
     let test_ev_1 = Event::from_data(TestIncrementEvent {
         by: 1,
-        ident: ident.into(),
+        ident: ident.clone(),
     });
 
     let test_ev_2 = Event::from_data(TestIncrementEvent {
         by: 2,
-        ident: ident.into(),
+        ident: ident.clone(),
     });
 
     assert!(block_on_all(store.save(&test_ev_1)).is_ok());

--- a/integration-tests.sql
+++ b/integration-tests.sql
@@ -15,7 +15,7 @@ CREATE TABLE events (
 DROP TABLE aggregate_cache;
 
 CREATE TABLE aggregate_cache (
-    id VARCHAR(63) PRIMARY KEY,
+    id VARCHAR(64) PRIMARY KEY,
     -- id character varying(64) PRIMARY KEY,
     data jsonb NOT NULL,
     time timestamp without time zone DEFAULT now()


### PR DESCRIPTION
This PR introduces some macros to aid testing with stateful PG backing
stores. The idea is that events related to a particular test can be
removed from the database before the test is run (again) by their
`ident` field. It's not perfect, but as long as the `ident` used in each
test is different, there shouldn't be (m)any conflicts. There is only a macro for emptying the _entire_ aggregate cache at this time, as it's all we need for now.