### PR TITLE
[S] Type/trait/lifetime cleanup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,10 @@ services:
       POSTGRES_DB: eventstorerust
 
   rabbit:
-    image: rabbitmq:3-alpine
+    image: rabbitmq:3-management-alpine
     ports:
       - "5673:5672"
+      - "15673:15672"
 
 
   integration_setup:

--- a/event-store/src/adapters/amqp/emitter.rs
+++ b/event-store/src/adapters/amqp/emitter.rs
@@ -237,13 +237,14 @@ impl EmitterAdapter for AMQPEmitterAdapter {
         let event_name = ED::event_type();
         let event_namespace = ED::event_namespace();
         let queue_name = format!("{}.{}", event_namespace, event_name);
-        let exchange = self.exchange.clone();
+        let _exchange = self.exchange.clone();
+        let _uri = self.uri;
 
         trace!("Creating queue {}", queue_name);
 
         thread::spawn(move || {
-            let consumer = connect(self.uri, self.exchange.clone())
-                .and_then(|(_, channel)| create_consumer(channel, queue_name, exchange, handler));
+            let consumer = connect(_uri, _exchange.clone())
+                .and_then(|(_, channel)| create_consumer(channel, queue_name, _exchange, handler));
 
             trace!("Begin listen");
 

--- a/event-store/src/adapters/amqp/emitter.rs
+++ b/event-store/src/adapters/amqp/emitter.rs
@@ -195,7 +195,7 @@ fn connect(
 }
 
 impl EmitterAdapter for AMQPEmitterAdapter {
-    fn emit<'a, E: EventData + Sync>(&self, event: &Event<E>) -> Result<(), io::Error> {
+    fn emit<E: EventData>(&self, event: &Event<E>) -> Result<(), io::Error> {
         let payload: Vec<u8> = serde_json::to_string(event)
             .expect("Cant serialise event")
             .into();
@@ -228,7 +228,7 @@ impl EmitterAdapter for AMQPEmitterAdapter {
         Runtime::new().unwrap().block_on(fut)
     }
 
-    fn subscribe<'a, ED, H>(&self, handler: H) -> BoxedFuture<'a, (), ()>
+    fn subscribe<ED, H>(&self, handler: H) -> BoxedFuture<(), ()>
     where
         ED: EventData + 'static,
         H: Fn(&Event<ED>) -> () + Send + 'static,

--- a/event-store/src/adapters/amqp/emitter.rs
+++ b/event-store/src/adapters/amqp/emitter.rs
@@ -14,6 +14,7 @@ use serde_json;
 use std::io;
 use std::net::SocketAddr;
 use std::str;
+use std::thread::{self, JoinHandle};
 use tokio;
 use tokio::net::TcpStream;
 use tokio::runtime::Runtime;
@@ -90,7 +91,7 @@ fn create_consumer<H, E>(
 ) -> impl Future<Item = (), Error = ()> + Send + 'static
 where
     E: EventData + 'static,
-    H: Fn(&Event<E>) -> () + Send + 'static,
+    H: Fn(Event<E>) -> () + Send + 'static,
 {
     let event_namespace = E::event_namespace();
     let event_type = E::event_type();
@@ -145,7 +146,7 @@ where
                 let payload = str::from_utf8(&message.data).unwrap();
                 let data: Event<E> = serde_json::from_str(payload).unwrap();
                 trace!("Received message with ID {}: {}", data.id, payload);
-                handler(&data);
+                handler(data);
                 channel.basic_ack(message.delivery_tag, false)
             })
         })
@@ -228,10 +229,10 @@ impl EmitterAdapter for AMQPEmitterAdapter {
         Runtime::new().unwrap().block_on(fut)
     }
 
-    fn subscribe<ED, H>(&self, handler: H) -> BoxedFuture<(), ()>
+    fn subscribe<ED, H>(&self, handler: H) -> JoinHandle<()>
     where
         ED: EventData + 'static,
-        H: Fn(&Event<ED>) -> () + Send + 'static,
+        H: Fn(Event<ED>) -> () + Send + 'static,
     {
         let event_name = ED::event_type();
         let event_namespace = ED::event_namespace();
@@ -240,9 +241,13 @@ impl EmitterAdapter for AMQPEmitterAdapter {
 
         trace!("Creating queue {}", queue_name);
 
-        let consumer = connect(self.uri, self.exchange.clone())
-            .and_then(|(_, channel)| create_consumer(channel, queue_name, exchange, handler));
+        thread::spawn(move || {
+            let consumer = connect(self.uri, self.exchange.clone())
+                .and_then(|(_, channel)| create_consumer(channel, queue_name, exchange, handler));
 
-        Box::new(consumer)
+            trace!("Begin listen");
+
+            Runtime::new().unwrap().block_on_all(consumer).unwrap();
+        })
     }
 }

--- a/event-store/src/adapters/mod.rs
+++ b/event-store/src/adapters/mod.rs
@@ -17,7 +17,6 @@ use event_store_derive_internals::EventData;
 use serde::{de::DeserializeOwned, Serialize};
 use std::io;
 use std::thread::JoinHandle;
-use utils::BoxedFuture;
 use Event;
 use Events;
 use StoreQuery;

--- a/event-store/src/adapters/mod.rs
+++ b/event-store/src/adapters/mod.rs
@@ -31,17 +31,17 @@ pub trait StoreAdapter<Q: StoreQuery>: Send + Sync + Clone + 'static {
     /// Save an event to the store
     fn save<ED>(&self, event: &Event<ED>) -> Result<(), String>
     where
-        ED: EventData + Send + Sync;
+        ED: EventData + Send;
 
     /// Returns the last event of the type ED
-    fn last_event<'b, ED: EventData + Send>(&self) -> Result<Option<Event<ED>>, String>;
+    fn last_event<ED: EventData + Send>(&self) -> Result<Option<Event<ED>>, String>;
 }
 
 /// Result of a cache search
 pub type CacheResult<T> = (T, DateTime<Utc>);
 
 /// Caching backend
-pub trait CacheAdapter {
+pub trait CacheAdapter: Clone + Send + Sync + 'static {
     /// Insert an item into the cache
     fn set<V>(&self, key: String, value: V) -> Result<(), String>
     where
@@ -56,9 +56,9 @@ pub trait CacheAdapter {
 /// Closure called when an incoming event must be handled
 
 /// Event emitter interface
-pub trait EmitterAdapter: Send + Sync + Clone + 'static {
+pub trait EmitterAdapter: Clone + Send + Sync + 'static {
     /// Emit an event
-    fn emit<E: EventData + Sync>(&self, event: &Event<E>) -> Result<(), io::Error>;
+    fn emit<E: EventData + Send>(&self, event: &Event<E>) -> Result<(), io::Error>;
 
     /// Subscribe to an event
     fn subscribe<ED, H>(&self, handler: H) -> JoinHandle<()>

--- a/event-store/src/adapters/mod.rs
+++ b/event-store/src/adapters/mod.rs
@@ -16,6 +16,7 @@ use chrono::{DateTime, Utc};
 use event_store_derive_internals::EventData;
 use serde::{de::DeserializeOwned, Serialize};
 use std::io;
+use std::thread::JoinHandle;
 use utils::BoxedFuture;
 use Event;
 use Events;
@@ -61,8 +62,8 @@ pub trait EmitterAdapter: Send + Sync + Clone + 'static {
     fn emit<E: EventData + Sync>(&self, event: &Event<E>) -> Result<(), io::Error>;
 
     /// Subscribe to an event
-    fn subscribe<ED, H>(&self, handler: H) -> BoxedFuture<(), ()>
+    fn subscribe<ED, H>(&self, handler: H) -> JoinHandle<()>
     where
         ED: EventData + 'static,
-        H: Fn(&Event<ED>) -> () + Send + Sync + 'static;
+        H: Fn(Event<ED>) -> () + Send + Sync + 'static;
 }

--- a/event-store/src/adapters/mod.rs
+++ b/event-store/src/adapters/mod.rs
@@ -25,17 +25,16 @@ use StoreQuery;
 pub trait StoreAdapter<Q: StoreQuery>: Send + Sync + Clone + 'static {
     /// Read a list of events matching a query
 
-    fn read<'b, E>(&self, query: Q, since: Option<DateTime<Utc>>) -> Result<Vec<E>, String>
+    fn read<E>(&self, query: Q, since: Option<DateTime<Utc>>) -> Result<Vec<E>, String>
     where
-        E: Events + Send + 'b,
-        Q: 'b;
+        E: Events + Send;
     /// Save an event to the store
-    fn save<'b, ED>(&self, event: &'b Event<ED>) -> Result<(), String>
+    fn save<ED>(&self, event: &Event<ED>) -> Result<(), String>
     where
-        ED: EventData + Send + Sync + 'b;
+        ED: EventData + Send + Sync;
 
     /// Returns the last event of the type ED
-    fn last_event<'b, ED: EventData + Send + 'b>(&self) -> Result<Option<Event<ED>>, String>;
+    fn last_event<'b, ED: EventData + Send>(&self) -> Result<Option<Event<ED>>, String>;
 }
 
 /// Result of a cache search
@@ -44,14 +43,14 @@ pub type CacheResult<T> = (T, DateTime<Utc>);
 /// Caching backend
 pub trait CacheAdapter {
     /// Insert an item into the cache
-    fn set<'a, V>(&self, key: String, value: V) -> Result<(), String>
+    fn set<V>(&self, key: String, value: V) -> Result<(), String>
     where
-        V: Serialize + Send + 'a;
+        V: Serialize + Send;
 
     /// Retrieve an item from the cache
-    fn get<'a, T>(&self, key: String) -> Result<Option<CacheResult<T>>, String>
+    fn get<T>(&self, key: String) -> Result<Option<CacheResult<T>>, String>
     where
-        T: DeserializeOwned + Send + 'a;
+        T: DeserializeOwned + Send;
 }
 
 /// Closure called when an incoming event must be handled
@@ -59,10 +58,10 @@ pub trait CacheAdapter {
 /// Event emitter interface
 pub trait EmitterAdapter: Send + Sync + Clone + 'static {
     /// Emit an event
-    fn emit<'a, E: EventData + Sync>(&self, event: &Event<E>) -> Result<(), io::Error>;
+    fn emit<E: EventData + Sync>(&self, event: &Event<E>) -> Result<(), io::Error>;
 
     /// Subscribe to an event
-    fn subscribe<'a, ED, H>(&self, handler: H) -> BoxedFuture<'a, (), ()>
+    fn subscribe<ED, H>(&self, handler: H) -> BoxedFuture<(), ()>
     where
         ED: EventData + 'static,
         H: Fn(&Event<ED>) -> () + Send + Sync + 'static;

--- a/event-store/src/adapters/pg/cache.rs
+++ b/event-store/src/adapters/pg/cache.rs
@@ -20,7 +20,7 @@ impl PgCacheAdapter {
 }
 
 impl CacheAdapter for PgCacheAdapter {
-    fn set<'a, V: Serialize + Send + 'a>(&self, key: String, value: V) -> Result<(), String> {
+    fn set<V: Serialize + Send>(&self, key: String, value: V) -> Result<(), String> {
         self.conn
             .get()
             .expect("Could not get PG connection")
@@ -35,9 +35,9 @@ impl CacheAdapter for PgCacheAdapter {
             .map_err(|_| "Failed to set cache item".into())
     }
 
-    fn get<'a, T>(&self, key: String) -> Result<Option<CacheResult<T>>, String>
+    fn get<T>(&self, key: String) -> Result<Option<CacheResult<T>>, String>
     where
-        T: DeserializeOwned + Send + 'a,
+        T: DeserializeOwned + Send,
     {
         let rows = self
             .conn

--- a/event-store/src/adapters/pg/mod.rs
+++ b/event-store/src/adapters/pg/mod.rs
@@ -16,15 +16,15 @@ type Connection = Pool<PostgresConnectionManager>;
 
 /// Representation of a Postgres query and args
 #[derive(Debug)]
-pub struct PgQuery<'a> {
+pub struct PgQuery {
     /// Query string with placeholders
-    pub query: &'a str,
+    pub query: String,
 
     /// Arguments to use for the query
-    pub args: Vec<Box<ToSql + Send + Sync>>,
+    pub args: Vec<Box<ToSql>>,
 }
 
-impl<'a> StoreQuery for PgQuery<'a> {
+impl StoreQuery for PgQuery {
     fn unique_id(&self) -> String {
         let hash = Sha256::digest(format!("{:?}:[{}]", self.args, self.query).as_bytes());
         hash.iter().fold(String::new(), |mut acc, hex| {
@@ -34,10 +34,13 @@ impl<'a> StoreQuery for PgQuery<'a> {
     }
 }
 
-impl<'a> PgQuery<'a> {
+impl PgQuery {
     /// Create a new query from a query string and arguments
-    pub fn new(query: &'a str, args: Vec<Box<ToSql + Send + Sync>>) -> Self {
-        Self { query, args }
+    pub fn new(query: &str, args: Vec<Box<ToSql>>) -> Self {
+        Self {
+            query: query.into(),
+            args,
+        }
     }
 }
 

--- a/event-store/src/adapters/pg/store.rs
+++ b/event-store/src/adapters/pg/store.rs
@@ -22,13 +22,13 @@ pub struct PgStoreAdapter {
     pool: Pool<PostgresConnectionManager>,
 }
 
-impl<'a> PgStoreAdapter {
+impl PgStoreAdapter {
     /// Create a new PgStore from a Postgres DB connection
     pub fn new(conn: Pool<PostgresConnectionManager>) -> Self {
         Self { pool: conn }
     }
 
-    fn generate_query(initial_query: &PgQuery<'a>, since: Option<DateTime<Utc>>) -> String {
+    fn generate_query(initial_query: &PgQuery, since: Option<DateTime<Utc>>) -> String {
         if let Some(timestamp) = since {
             String::from(format!(
             "SELECT * FROM ({}) AS events WHERE events.context->>'time' >= '{}' ORDER BY events.context->>'time' ASC",
@@ -43,14 +43,10 @@ impl<'a> PgStoreAdapter {
     }
 }
 
-impl<'a> StoreAdapter<PgQuery<'a>> for PgStoreAdapter {
-    fn read<'b, E>(
-        &self,
-        query: PgQuery<'b>,
-        since: Option<DateTime<Utc>>,
-    ) -> Result<Vec<E>, String>
+impl StoreAdapter<PgQuery> for PgStoreAdapter {
+    fn read<E>(&self, query: PgQuery, since: Option<DateTime<Utc>>) -> Result<Vec<E>, String>
     where
-        E: Events + Send + 'b,
+        E: Events + Send,
     {
         let conn = self.pool.clone();
 
@@ -97,10 +93,7 @@ impl<'a> StoreAdapter<PgQuery<'a>> for PgStoreAdapter {
         Ok(results)
     }
 
-    fn save<'b, ED: EventData + Sync + Send + 'b>(
-        &self,
-        event: &'b Event<ED>,
-    ) -> Result<(), String> {
+    fn save<ED: EventData + Sync + Send>(&self, event: &Event<ED>) -> Result<(), String> {
         self.pool
             .get()
             .expect("Could not connect to the pool (save)")
@@ -120,7 +113,7 @@ impl<'a> StoreAdapter<PgQuery<'a>> for PgStoreAdapter {
             })
     }
 
-    fn last_event<'b, ED: EventData + Send + 'b>(&self) -> Result<Option<Event<ED>>, String> {
+    fn last_event<ED: EventData + Send>(&self) -> Result<Option<Event<ED>>, String> {
         let rows = self.pool
                 .get()
                 .expect("Could not connect to the pool (last_event)")

--- a/event-store/src/adapters/pg/store.rs
+++ b/event-store/src/adapters/pg/store.rs
@@ -93,7 +93,7 @@ impl StoreAdapter<PgQuery> for PgStoreAdapter {
         Ok(results)
     }
 
-    fn save<ED: EventData + Sync + Send>(&self, event: &Event<ED>) -> Result<(), String> {
+    fn save<ED: EventData + Send>(&self, event: &Event<ED>) -> Result<(), String> {
         self.pool
             .get()
             .expect("Could not connect to the pool (save)")

--- a/event-store/src/adapters/stub/emitter.rs
+++ b/event-store/src/adapters/stub/emitter.rs
@@ -19,11 +19,11 @@ impl StubEmitterAdapter {
 }
 
 impl EmitterAdapter for StubEmitterAdapter {
-    fn emit<'a, E: EventData>(&self, _event: &Event<E>) -> Result<(), Error> {
+    fn emit<E: EventData>(&self, _event: &Event<E>) -> Result<(), Error> {
         Ok(())
     }
 
-    fn subscribe<'a, ED, H>(&self, _handler: H) -> BoxedFuture<'a, (), ()>
+    fn subscribe<ED, H>(&self, _handler: H) -> BoxedFuture<(), ()>
     where
         ED: EventData + 'static,
         H: Fn(&Event<ED>) -> (),

--- a/event-store/src/adapters/stub/emitter.rs
+++ b/event-store/src/adapters/stub/emitter.rs
@@ -4,6 +4,7 @@ use adapters::EmitterAdapter;
 use event_store_derive_internals::EventData;
 use futures::future::ok as FutOk;
 use std::io::Error;
+use std::thread::{self, JoinHandle};
 use utils::BoxedFuture;
 use Event;
 
@@ -23,11 +24,13 @@ impl EmitterAdapter for StubEmitterAdapter {
         Ok(())
     }
 
-    fn subscribe<ED, H>(&self, _handler: H) -> BoxedFuture<(), ()>
+    fn subscribe<ED, H>(&self, _handler: H) -> JoinHandle<()>
     where
         ED: EventData + 'static,
-        H: Fn(&Event<ED>) -> (),
+        H: Fn(Event<ED>) -> (),
     {
-        Box::new(FutOk(()))
+        thread::spawn(move || {
+            println!("Stub subscribe");
+        })
     }
 }

--- a/event-store/src/adapters/stub/emitter.rs
+++ b/event-store/src/adapters/stub/emitter.rs
@@ -2,10 +2,8 @@
 
 use adapters::EmitterAdapter;
 use event_store_derive_internals::EventData;
-use futures::future::ok as FutOk;
 use std::io::Error;
 use std::thread::{self, JoinHandle};
-use utils::BoxedFuture;
 use Event;
 
 /// Stub event emitter

--- a/event-store/src/aggregator.rs
+++ b/event-store/src/aggregator.rs
@@ -1,4 +1,5 @@
 use event_store_derive_internals::Events;
+use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use store_query::StoreQuery;
 
@@ -145,7 +146,9 @@ use store_query::StoreQuery;
 ///     }
 /// }
 /// ```
-pub trait Aggregator<E: Events, A: Clone, Q: StoreQuery>: Clone + Debug + Default {
+pub trait Aggregator<E: Events, A: Clone, Q: StoreQuery>:
+    Clone + Debug + Default + Send + PartialEq + Serialize + for<'de> Deserialize<'de>
+{
     /// Apply an event `E` to `acc`, returning a copy of `Self` with updated fields. Can also just
     /// return `acc` if nothing has changed.
     fn apply_event(acc: Self, event: &E) -> Self;

--- a/event-store/src/aggregator.rs
+++ b/event-store/src/aggregator.rs
@@ -58,7 +58,7 @@ use store_query::StoreQuery;
 /// }
 ///
 /// // The domain entity we want to aggregate to
-/// #[derive(Clone, Debug, PartialEq)]
+/// #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 /// struct UserDetails {
 ///     name: String,
 ///     email: String,

--- a/event-store/src/lib.rs
+++ b/event-store/src/lib.rs
@@ -135,10 +135,7 @@ where
     }
 
     /// Save an event to the store with optional context
-    fn save<'b, ED: EventData + Send + Sync + 'b>(
-        &'b self,
-        event: &'b Event<ED>,
-    ) -> Result<(), String> {
+    fn save<ED: EventData + Send + Sync>(&self, event: &Event<ED>) -> Result<(), String> {
         self.store.save(event)?;
 
         self.emitter

--- a/event-store/src/store.rs
+++ b/event-store/src/store.rs
@@ -7,33 +7,27 @@ use std::thread::JoinHandle;
 use store_query::StoreQuery;
 
 /// Store trait
-pub trait Store<
-    'a,
-    Q: StoreQuery + Send + Sync + 'a,
-    S: StoreAdapter<Q> + Send + Sync,
-    C: CacheAdapter + 'static,
-    EM: EmitterAdapter + Send + Sync,
->: Send + Sync + Clone + 'a
+pub trait Store<Q, S, C, EM>: Clone
+where
+    Q: StoreQuery,
+    S: StoreAdapter<Q>,
+    C: CacheAdapter + Clone + Send + Sync + 'static,
+    EM: EmitterAdapter + Send + Sync + 'static,
 {
     /// Create a new event store
     fn new(store: S, cache: C, emitter: EM) -> Self;
 
     /// Query the backing store and return an entity `T`, reduced from queried events
-    fn aggregate<'b, E, T, A>(&'b self, query: A) -> Result<T, String>
+    fn aggregate<E, T, A>(&self, query: A) -> Result<T, String>
     where
-        E: Events + Send + Sync + 'b,
-        Q: 'b,
-        T: Aggregator<E, A, Q>
-            + Send
-            + Sync
-            + Serialize
-            + for<'de> Deserialize<'de>
-            + PartialEq
-            + 'b,
-        A: Clone + 'b;
+        E: Events + Send,
+        T: Aggregator<E, A, Q> + Serialize + for<'de> Deserialize<'de> + PartialEq + Send,
+        A: Clone;
 
     /// Save an event to the store with optional context
-    fn save<ED: EventData + Send + Sync>(&self, event: &Event<ED>) -> Result<(), String>;
+    fn save<ED>(&self, event: &Event<ED>) -> Result<(), String>
+    where
+        ED: EventData + Send;
 
     /// Subscribe to an event
     fn subscribe<ED, H>(&self, handler: H) -> Result<JoinHandle<()>, ()>

--- a/event-store/src/store.rs
+++ b/event-store/src/store.rs
@@ -39,5 +39,5 @@ pub trait Store<
     fn subscribe<ED, H>(&self, handler: H) -> Result<JoinHandle<()>, ()>
     where
         ED: EventData + Send + Sync + 'static,
-        H: Fn(&Event<ED>, &Self) -> () + Send + Sync + 'static;
+        H: Fn(Event<ED>, &Self) -> () + Send + Sync + 'static;
 }

--- a/event-store/src/store.rs
+++ b/event-store/src/store.rs
@@ -33,10 +33,7 @@ pub trait Store<
         A: Clone + 'b;
 
     /// Save an event to the store with optional context
-    fn save<'b, ED: EventData + Send + Sync + 'b>(
-        &'b self,
-        event: &'b Event<ED>,
-    ) -> Result<(), String>;
+    fn save<ED: EventData + Send + Sync>(&self, event: &Event<ED>) -> Result<(), String>;
 
     /// Subscribe to an event
     fn subscribe<ED, H>(&self, handler: H) -> Result<JoinHandle<()>, ()>

--- a/event-store/src/store.rs
+++ b/event-store/src/store.rs
@@ -11,8 +11,8 @@ pub trait Store<Q, S, C, EM>: Clone
 where
     Q: StoreQuery,
     S: StoreAdapter<Q>,
-    C: CacheAdapter + Clone + Send + Sync + 'static,
-    EM: EmitterAdapter + Send + Sync + 'static,
+    C: CacheAdapter,
+    EM: EmitterAdapter,
 {
     /// Create a new event store
     fn new(store: S, cache: C, emitter: EM) -> Self;

--- a/event-store/src/testhelpers.rs
+++ b/event-store/src/testhelpers.rs
@@ -54,7 +54,7 @@ impl Default for TestCounterEntity {
     }
 }
 
-impl<'a> Aggregator<TestEvents, String, PgQuery<'a>> for TestCounterEntity {
+impl Aggregator<TestEvents, String, PgQuery> for TestCounterEntity {
     fn apply_event(acc: Self, event: &TestEvents) -> Self {
         let counter = match event {
             TestEvents::Inc(ref inc) => acc.counter + inc.data.by,
@@ -64,8 +64,8 @@ impl<'a> Aggregator<TestEvents, String, PgQuery<'a>> for TestCounterEntity {
         Self { counter, ..acc }
     }
 
-    fn query(field: String) -> PgQuery<'a> {
-        let mut params: Vec<Box<ToSql + Send + Sync>> = Vec::new();
+    fn query(field: String) -> PgQuery {
+        let mut params: Vec<Box<ToSql>> = Vec::new();
 
         params.push(Box::new(field));
 

--- a/event-store/tests/amqp.rs
+++ b/event-store/tests/amqp.rs
@@ -33,17 +33,11 @@ fn emitter_emits_and_subscribes() {
         .block_on(AMQPEmitterAdapter::new(addr, "iris".into()))
         .expect("Could not start AMQP sender");
 
-    let sub = amqp.subscribe(move |_event: &Event<TestIncrementEvent>| {
+    let sub = amqp.subscribe(move |_event: Event<TestIncrementEvent>| {
         println!("Received test event");
 
         &sh.lock().unwrap().send(()).unwrap();
     });
-
-    let mut rt = Runtime::new().expect("Subscriber runtime could not be created");
-
-    println!("Spawn subscriber thread");
-
-    rt.spawn(sub);
 
     thread::sleep(time::Duration::from_millis(100));
 
@@ -54,4 +48,6 @@ fn emitter_emits_and_subscribes() {
     .expect("Could not send event");
 
     assert!(rx.recv_timeout(Duration::from_secs(5)).is_ok());
+
+    sub.join().unwrap();
 }

--- a/event-store/tests/amqp.rs
+++ b/event-store/tests/amqp.rs
@@ -33,7 +33,7 @@ fn emitter_emits_and_subscribes() {
         .block_on(AMQPEmitterAdapter::new(addr, "iris".into()))
         .expect("Could not start AMQP sender");
 
-    let sub = amqp.subscribe(move |_event: Event<TestIncrementEvent>| {
+    let _sub = amqp.subscribe(move |_event: Event<TestIncrementEvent>| {
         println!("Received test event");
 
         &sh.lock().unwrap().send(()).unwrap();
@@ -48,6 +48,4 @@ fn emitter_emits_and_subscribes() {
     .expect("Could not send event");
 
     assert!(rx.recv_timeout(Duration::from_secs(5)).is_ok());
-
-    sub.join().unwrap();
 }


### PR DESCRIPTION
This PR cleans the codebase somewhat by:

* Removing almost all explicit lifetimes, except some `'static`s in certain places. Most removals were a direct result of using a `String` in `PgQuery` instead of a `&'a str`. Perhaps `&'static str` could be used instead?
* Moving required extra trait bounds onto the trait definitions, instead of the store. This means that the trait definition for `Store` is nice and clean:

```rust
/// Store trait
pub trait Store<Q, S, C, EM>: Clone
where
    Q: StoreQuery,
    S: StoreAdapter<Q>,
    C: CacheAdapter,
    EM: EmitterAdapter,
{
    // ...
}
```

* Consuming received events in event handlers. The event argument should not be a reference, but should be moved into the handler.
* Fixing #55 

It also moves to spawning a thread for each subscription instead of `.subscribe()` returning a future. This seems to clean up passing of the store into subscribers nicely.

**For a future PR:** Currently, the type system doesn't prevent the programmer from spawning another subscription from within a subscription handler. This is an antipattern and should be disallowed by splitting the store into a `Store` and `SubscribableStore` (or other suitable names). Only the latter has a `subscribe()` method, and the former is passed into event handlers. This prevents nested subscriptions.