### PR TITLE
[F] Don't panic when event cannot be parsed

### DIFF
--- a/event-store/src/adapters/emitter/amqp.rs
+++ b/event-store/src/adapters/emitter/amqp.rs
@@ -141,6 +141,12 @@ impl AmqpEmitterAdapter {
                                 .expect("Could not ack message");
                         }
                         Err(e) => {
+                            trace!(
+                                "Failed event payload: {}",
+                                String::from_utf8(message.data.clone())
+                                    .unwrap_or(String::from("(failed to decode message)"))
+                            );
+
                             serde_json::from_slice::<JsonValue>(&message.data)
                                 .map(|evt| {
                                     error!(


### PR DESCRIPTION
This PR gracefully handles event parse errors, meaning the handler thread no longer panics. Invalid events are error-logged and ignored, whilst further events in the stream are handled.