### PR TITLE
[F] Create PG tables on startup

### DIFF
--- a/event-store/src/internals/test_helpers.rs
+++ b/event-store/src/internals/test_helpers.rs
@@ -99,26 +99,5 @@ pub fn pg_create_random_db(suffix: Option<&str>) -> Pool<PostgresConnectionManag
 
     let pool = r2d2::Pool::new(manager).unwrap();
 
-    let conn = pool.get().unwrap();
-
-    conn.batch_execute(
-        r#"
-        CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-
-        CREATE TABLE events (
-            id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
-            data jsonb NOT NULL,
-            context jsonb DEFAULT '{}'::jsonb
-        );
-
-        CREATE TABLE aggregate_cache (
-            id VARCHAR(64) PRIMARY KEY,
-            data jsonb NOT NULL,
-            time timestamp without time zone DEFAULT now()
-        );
-    "#,
-    )
-    .unwrap();
-
     pool
 }


### PR DESCRIPTION
This PR now creates the cache and events PG tables and indexes on startup, requiring less setup.

Closes #72 

Note that the aggregate cache `time` column is now a `timestamp with time zone`. This will bork with existing cache tables created by the Typescript event store, so they will need to be migrated to work with the Rust version.