### PR TITLE
[S] Unifier take 2

### DIFF
--- a/unifier/Cargo.toml
+++ b/unifier/Cargo.toml
@@ -24,3 +24,6 @@ features = ["serde"]
 [dependencies.uuid]
 version = "0.7.4"
 features = ["serde", "v4"]
+
+[dev-dependencies]
+maplit = "1.0.1"

--- a/unifier/src/event.rs
+++ b/unifier/src/event.rs
@@ -1,10 +1,10 @@
 use chrono::prelude::*;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
 use uuid::Uuid;
 
 /// Event data
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(serde_derive::Serialize, serde_derive::Deserialize, Debug, Clone)]
 pub struct EventData {
     pub event_namespace: String,
     pub event_type: String,
@@ -18,12 +18,54 @@ pub struct EventData {
     legacy_type: String,
 }
 
+/// Serialize an optional subject so that a `None` value serializes to the empty object `{}`
+fn serialize_subject<S>(
+    subject: &Option<HashMap<String, serde_json::Value>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if let Some(subject) = subject {
+        subject.serialize(serializer)
+    } else {
+        serde_json::json!({}).serialize(serializer)
+    }
+}
+
+/// Convert an empty object `{}` to `None` for subjects
+fn deserialize_subject<'de, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<String, serde_json::Value>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let res = Option::deserialize(deserializer)?.and_then(
+        |hashmap: HashMap<String, serde_json::Value>| {
+            if hashmap.len() > 0 {
+                Some(hashmap)
+            } else {
+                None
+            }
+        },
+    );
+
+    Ok(res)
+}
+
 /// Event context
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(serde_derive::Serialize, serde_derive::Deserialize, Debug, Clone)]
 pub struct EventContext {
     pub action: Option<String>,
 
     /// Event "subject" or metadata
+    ///
+    /// For backwards compatibility reasons, if the value of `subject` is `None`, it serializes to
+    /// an empty object `{}`. If an empty object is encountered during deserialization it is mapped
+    /// to `None`.
+    #[serde(default)]
+    #[serde(serialize_with = "serialize_subject")]
+    #[serde(deserialize_with = "deserialize_subject")]
     pub subject: Option<HashMap<String, serde_json::Value>>,
 
     /// Event creation time
@@ -31,7 +73,7 @@ pub struct EventContext {
 }
 
 /// An event
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(serde_derive::Serialize, serde_derive::Deserialize, Debug, Clone)]
 pub struct Event {
     pub id: Uuid,
     pub data: EventData,

--- a/unifier/src/event.rs
+++ b/unifier/src/event.rs
@@ -79,3 +79,86 @@ pub struct Event {
     pub data: EventData,
     pub context: EventContext,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use maplit::hashmap;
+    use serde_json::json;
+    use std::error::Error;
+
+    #[test]
+    fn deserialize_populated_subject() -> Result<(), Box<Error>> {
+        let res: EventContext = serde_json::from_value(json!({
+            "action": null,
+            "subject": {
+                "foo": "bar"
+            },
+            "time": "2019-04-03T13:40:55.901Z"
+        }))?;
+
+        assert_eq!(
+            res.subject,
+            Some(hashmap! {
+                "foo".to_string() => json!("bar")
+            })
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn deserialize_empty_subject() -> Result<(), Box<Error>> {
+        let res: EventContext = serde_json::from_value(json!({
+            "action": null,
+            "subject": {},
+            "time": "2019-04-03T13:40:55.901Z"
+        }))?;
+
+        assert_eq!(res.subject, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn serialize_populated_subject() -> Result<(), Box<Error>> {
+        let res = serde_json::to_value(EventContext {
+            action: None,
+            subject: Some(hashmap! { "foo".to_string() => json!("bar") }),
+            time: "2019-04-03T13:40:55.901Z".parse()?,
+        })?;
+
+        assert_eq!(
+            res,
+            json!({
+                "action": null,
+                "subject": {
+                    "foo": "bar"
+                },
+                "time": "2019-04-03T13:40:55.901Z"
+            })
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn serialize_empty_subject() -> Result<(), Box<Error>> {
+        let res = serde_json::to_value(EventContext {
+            action: None,
+            subject: None,
+            time: "2019-04-03T13:40:55.901Z".parse()?,
+        })?;
+
+        assert_eq!(
+            res,
+            json!({
+                "action": null,
+                "subject": {},
+                "time": "2019-04-03T13:40:55.901Z"
+            })
+        );
+
+        Ok(())
+    }
+}

--- a/unifier/src/event.rs
+++ b/unifier/src/event.rs
@@ -24,8 +24,7 @@ pub struct EventContext {
     pub action: Option<String>,
 
     /// Event "subject" or metadata
-    #[serde(default)]
-    pub subject: HashMap<String, serde_json::Value>,
+    pub subject: Option<HashMap<String, serde_json::Value>>,
 
     /// Event creation time
     pub time: DateTime<Utc>,

--- a/unifier/src/main.rs
+++ b/unifier/src/main.rs
@@ -114,9 +114,9 @@ fn main() -> Result<(), String> {
     let stmt = txn
         .prepare(
             "insert into events (id, data, context) values ($1, $2, $3)
-            on conflict do update set
-            events.data = excluded.data,
-            events.context = excluded.context",
+            on conflict (id) do update set
+            data = excluded.data,
+            context = excluded.context",
         )
         .map_err(|e| e.to_string())?;
 

--- a/unifier/src/main.rs
+++ b/unifier/src/main.rs
@@ -112,7 +112,12 @@ fn main() -> Result<(), String> {
 
     let mut txn = dest_connection.transaction().map_err(|e| e.to_string())?;
     let stmt = txn
-        .prepare("insert into events (id, data, context) values ($1, $2, $3)")
+        .prepare(
+            "insert into events (id, data, context) values ($1, $2, $3)
+            on conflict do update set
+            events.data = excluded.data,
+            events.context = excluded.context",
+        )
         .map_err(|e| e.to_string())?;
 
     if args.truncate_dest {


### PR DESCRIPTION
Summary

* Updates existing events if one with a duplicate ID exists.
* Serializes empty `context.subject`s to `{}` instead of `null` for backwards compatibility reasons.
* Deserializes `context.subject`s that equal `{}` to Rust `None`s for better ergonomics.