### PR TITLE
[B] Changed quote::__rt to quote::__private and updated quote version

### DIFF
--- a/event-store-derive/Cargo.toml
+++ b/event-store-derive/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 syn = { version = "0.15.34", features = [ "extra-traits" ] }
-quote = "0.6.12"
+quote = "1.0.3"
 proc-macro2 = "0.4.30"
 serde = "1.0.91"
 serde_derive = "1.0.91"

--- a/event-store-derive/src/ns.rs
+++ b/event-store-derive/src/ns.rs
@@ -3,7 +3,7 @@ use crate::derive_struct::derive_struct;
 use crate::PROC_MACRO_NAME;
 use proc_macro2::{Ident, Span, TokenStream, TokenTree};
 use quote::ToTokens;
-use quote::__rt::TokenTree::Group;
+use quote::__private::TokenTree::Group;
 use std::string::ToString;
 use syn::{Attribute, Data, DataEnum, DataStruct, DeriveInput, Fields, FieldsNamed, Generics};
 


### PR DESCRIPTION
This is exploratory. Running cargo update did not change Cargo.lock
(either before or after these changes).

The risk is that there were a lot of changes in quote between 0.6.12 and 1.0.3,
(especially between 0.6.13 and 1.0.0), some of which might break its usage in event-store-derive/src/ns.rs.

Strangely, cargo format reports 49 errors in use of 'await' (a string that does not
occur in either version 0.6.12 or 1.0.3 of quote) but these errors are also reported
in master.